### PR TITLE
Display logins history links below each other instead of in line

### DIFF
--- a/adminer.css
+++ b/adminer.css
@@ -567,7 +567,8 @@ input.required { box-shadow: 1px 1px 1px red; }
 .help { cursor: help; }
 .logout { margin-top: .5em; position: absolute; top: 0; right: 0; }
 #dbs { overflow: hidden; }
-#logins, #tables { white-space: nowrap; overflow: auto; }
+#tables { white-space: nowrap; overflow: auto; }
+#logins a{ width: 100%; display: inline-block; }
 #h1 { color: #777; text-decoration: none; font-style: italic; }
 #version { font-size: 67%; color: red; }
 #schema { margin-left: 60px; position: relative; -moz-user-select: none; -webkit-user-select: none; }


### PR DESCRIPTION
In your version the logins history links are displayed in one long line and can't be clicked. 