### PR TITLE
Fixed logout button position

### DIFF
--- a/adminer.css
+++ b/adminer.css
@@ -582,7 +582,7 @@ input.required { box-shadow: 1px 1px 1px red; }
 .icon:hover { background-color: red; }
 .size { width: 6ex; }
 .help { cursor: help; }
-.logout { margin-top: .5em; position: absolute; top: 0; right: 0; z-index: 1; }
+.logout { margin-top: .5em; position: fixed; top: 0; right: 0; z-index: 1; }
 .loadmore { margin-left: 1ex; }
 #dbs { overflow: hidden; }
 #logins, #tables { white-space: nowrap; overflow: auto; }


### PR DESCRIPTION
When you have tables with many columns and start scrolling horizontally, the logout button is moving as well. This commit fixes it.