### PR TITLE
Preserve PHP5.6 compability

### DIFF
--- a/plugins/dump-php-prototype.php
+++ b/plugins/dump-php-prototype.php
@@ -118,7 +118,7 @@ class AdminerDumpPhpPrototype
 			echo "\tuse Nette\\SmartObject;\n";
 			foreach (fields($table) as $field => $info) {
 				$type = $this->detectType($info['type']);
-				$type = $this->phpTypes[$type] ?? $type;
+				$type = !empty($this->phpTypes[$type]) ? $this->phpTypes[$type] : $type;
 				if ($info['null']) {
 					$type = '?' . $type;
 				}


### PR DESCRIPTION
This one row prevents works custom adminer on PHP5.6. IMHO worth of change it to "older" syntax.