### PR TITLE
Fix cache busting for adminer.css

### DIFF
--- a/index.php
+++ b/index.php
@@ -11,7 +11,7 @@ define('ASSETS_VERSION', '1');
 
 if (empty($_GET['file'])) {
 	ob_start(function ($s) {
-		return preg_replace_callback('#(<(link|script)\s[^>]*(href|src)=")(adminer\.css|static/.+)"#U', function ($m) {
+		return preg_replace_callback('#(<(link|script)\s[^>]*(href|src)=")(adminer\.css|static/.+)(\?v=\d+)?"#U', function ($m) {
 			return $m[1] . '?file=' . urlencode($m[4]) . '&amp;version=' . ASSETS_VERSION . '"';
 		}, $s);
 	}, 4096);


### PR DESCRIPTION
admin.css is not loaded properly.
Caused by https://github.com/vrana/adminer/commit/7f32e2675941bd16f6d2f3c83df1a8c4ed970834